### PR TITLE
Set basic indent size to 4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@ insert_final_newline = true
 charset = utf-8
 max_line_length = 80
 trim_trailing_whitespace = true
+indent_size = 4
 
 [*.{html,js,sh,sass,scss,md,mmark,yaml}]
 indent_style = space


### PR DESCRIPTION
Set basic indent size to 4 in order for Go and Makefile sources in GitHub to be displayed with shorter indents instead of browsers’ default 8.